### PR TITLE
updated Subscription-Latest and DSC version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for terraform-azurerm-sharepoint
 
+## Unreleased
+
+- Value `Subscription-Latest` for parameter `sharePointVersion` now installs the April 2026 PU for SharePoint Subscription
+- Updated DSC configurations to [v2.3.0](https://github.com/Yvand/SharePointInfraDsc/releases/tag/releases%2Fv2.3.0), which contains [reliability improvements on the DC and SQL](https://github.com/Yvand/SharePointInfraDsc/blob/main/CHANGELOG.md#230---2026-04-15)
+- Minor update to the documentation
+
 ## [8.1.0] - 2026-04-02
 
 - Updated DSC configurations to [v2.1.0](https://github.com/Yvand/SharePointInfraDsc/releases/tag/releases%2Fv2.1.0), which contains [significant improvements](https://github.com/Yvand/SharePointInfraDsc/blob/main/CHANGELOG.md#210---2026-04-02)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ IMPORTANT: If you set variable `outbound_access_method` to `AzureFirewallProxy`,
 
 - Variable `resource_group_name` is used:
   - As the name of the Azure resource group which hosts all the resources that will be created.
-  - As part of the public DNS name of the virtual machines, if a public IP is created (depends on variable `add_public_ip_address`).
+  - As part of the public DNS name of the virtual machines, if they get a public IP (variable `outbound_access_method`), and a DNS name associated with it (variable `add_name_to_public_ip_addresses`).
 
 - Variable `enable_hybrid_benefit_server_licenses` allows you to enable Azure Hybrid Benefit to use your on-premises Windows Server licenses and reduce cost, if you are eligible. See [this page](https://docs.microsoft.com/azure/virtual-machines/windows/hybrid-use-benefit-licensing) for more information..
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ About SharePoint legacy: SharePoint 2016 / 2019 use outdated images ([2016](http
 ## SharePoint configuration
 
 - Variable `sharepoint_version` sets which version of SharePoint will be installed:
-  - `Subscription-Latest` (default): SharePoint Subscription with the latest public update available at the time of publishing this version: March 2026 ([KB5002843](https://support.microsoft.com/help/5002843)).
+  - `Subscription-Latest` (default): SharePoint Subscription with the latest public update available at the time of publishing this version: April  2026 ([KB5002853](https://support.microsoft.com/help/5002853)).
   - `Subscription-25H2`: SharePoint Subscription with the [Feature Update 25H2](https://learn.microsoft.com/sharepoint/what-s-new/new-improved-features-sharepoint-server-subscription-edition-2025-h2-release) (September 2025 PU / [KB5002784](https://support.microsoft.com/help/5002784)).
   - `Subscription-25H1`: SharePoint Subscription with the [Feature Update 25H1](https://learn.microsoft.com/sharepoint/what-s-new/new-and-improved-features-in-sharepoint-server-subscription-edition-25h1-release) (March 2025 PU / [KB5002698](https://support.microsoft.com/help/5002698)).
   - `Subscription-24H2`: SharePoint Subscription with the [Feature Update 24H2](https://learn.microsoft.com/sharepoint/what-s-new/new-and-improved-features-in-sharepoint-server-subscription-edition-24h2-release) (September 2024 PU / [kb5002640](https://support.microsoft.com/help/5002640)).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ About SharePoint legacy: SharePoint 2016 / 2019 use outdated images ([2016](http
 ## SharePoint configuration
 
 - Variable `sharepoint_version` sets which version of SharePoint will be installed:
-  - `Subscription-Latest` (default): SharePoint Subscription with the latest public update available at the time of publishing this version: April  2026 ([KB5002853](https://support.microsoft.com/help/5002853)).
+  - `Subscription-Latest` (default): SharePoint Subscription with the latest public update available at the time of publishing this version: April 2026 ([KB5002853](https://support.microsoft.com/help/5002853)).
   - `Subscription-25H2`: SharePoint Subscription with the [Feature Update 25H2](https://learn.microsoft.com/sharepoint/what-s-new/new-improved-features-sharepoint-server-subscription-edition-2025-h2-release) (September 2025 PU / [KB5002784](https://support.microsoft.com/help/5002784)).
   - `Subscription-25H1`: SharePoint Subscription with the [Feature Update 25H1](https://learn.microsoft.com/sharepoint/what-s-new/new-and-improved-features-in-sharepoint-server-subscription-edition-25h1-release) (March 2025 PU / [KB5002698](https://support.microsoft.com/help/5002698)).
   - `Subscription-24H2`: SharePoint Subscription with the [Feature Update 24H2](https://learn.microsoft.com/sharepoint/what-s-new/new-and-improved-features-in-sharepoint-server-subscription-edition-24h2-release) (September 2024 PU / [kb5002640](https://support.microsoft.com/help/5002640)).

--- a/configuration.tfvars
+++ b/configuration.tfvars
@@ -1,6 +1,8 @@
 location                        = "francecentral"
 sharepoint_version              = "Subscription-Latest" #"2019"
-outbound_access_method          = "PublicIPAddress"     #"AzureFirewallProxy"
+default_zone_must_be_https      = false
+sharepoint_configuration_level  = "Full"
+outbound_access_method          = "PublicIPAddress" #"AzureFirewallProxy"
 front_end_servers_count         = 0
 enable_azure_bastion            = false
 auto_shutdown_time              = "1930"
@@ -10,5 +12,3 @@ vm_sp_size                      = "Standard_B4as_v2"
 add_name_to_public_ip_addresses = "SharePointVMsOnly"
 add_default_tags                = true
 vm_availability_zone            = null
-default_zone_must_be_https      = true
-sharepoint_configuration_level  = "Minimum"

--- a/main.tf
+++ b/main.tf
@@ -107,7 +107,7 @@ locals {
       "Label" : "SPLatest",
       "Packages" : [
         {
-          "DownloadUrl" : "https://download.microsoft.com/download/9246c84a-1461-48be-8aee-6b99dc65f5cf/uber-subscription-kb5002843-fullfile-x64-glb.exe"
+          "DownloadUrl" : "https://download.microsoft.com/download/f839c57c-7b4e-4213-b03b-2c1508e13588/uber-subscription-kb5002853-fullfile-x64-glb.exe"
         }
       ]
     }

--- a/variables.tf
+++ b/variables.tf
@@ -393,7 +393,7 @@ variable "vm_sp_storage" {
 variable "_artifactsLocation" {
   type        = string
   description = "The base URI where artifacts required by this template are located including a trailing '/'"
-  default     = "https://github.com/Yvand/SharePointInfraDsc/releases/download/releases/v2.1.0/"
+  default     = "https://github.com/Yvand/SharePointInfraDsc/releases/download/releases/v2.3.0/"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "resource_group_name" {
 variable "location" {
   type        = string
   default     = "francecentral"
-  description = "The Azure region where this and supporting resources should be deployed."
+  description = "Location for all the resources."
   nullable    = false
 }
 
@@ -39,12 +39,6 @@ variable "sharepoint_version" {
   }
 }
 
-variable "default_zone_must_be_https" {
-  type        = bool
-  default     = false
-  description = "Set to true if the default zone of the main web application must use HTTPS protocol."
-}
-
 variable "sharepoint_configuration_level" {
   type        = string
   default     = "Light"
@@ -60,6 +54,12 @@ variable "sharepoint_configuration_level" {
     ], var.sharepoint_configuration_level)
     error_message = "Invalid value for sharepoint_configuration_level."
   }
+}
+
+variable "default_zone_must_be_https" {
+  type        = bool
+  default     = false
+  description = "Set to true if the default zone of the main web application must use HTTPS protocol."
 }
 
 variable "front_end_servers_count" {
@@ -135,7 +135,7 @@ variable "outbound_access_method" {
 variable "add_name_to_public_ip_addresses" {
   type        = string
   default     = "SharePointVMsOnly"
-  description = "Set if virtual machines should have a public DNS name, instead of just a public IP. Choose between 'No', 'SharePointVMsOnly' (default), and 'Yes'."
+  description = "If a virtual machine has a public IP address, specify if it should also have a public DNS name. Choose between 'No', 'SharePointVMsOnly' (default), and 'Yes'."
   validation {
     condition = contains([
       "No",
@@ -149,7 +149,7 @@ variable "add_name_to_public_ip_addresses" {
 variable "enable_azure_bastion" {
   type        = bool
   default     = false
-  description = "Specify if Azure Bastion Developer should be provisioned. See https://azure.microsoft.com/en-us/services/azure-bastion for more information."
+  description = "Specify if Azure Bastion Developer should be provisioned. See https://go.microsoft.com/fwlink/?linkid=2249215 for more information."
 }
 
 variable "enable_hybrid_benefit_server_licenses" {
@@ -161,7 +161,7 @@ variable "enable_hybrid_benefit_server_licenses" {
 variable "time_zone" {
   type        = string
   default     = "Romance Standard Time"
-  description = "Time zone of the virtual machines. Type '[TimeZoneInfo]::GetSystemTimeZones().Id' in PowerShell to get the list."
+  description = "Time zone of the virtual machines (also used for the variable auto_shutdown_time)."
   validation {
     condition = contains([
       "Dateline Standard Time",


### PR DESCRIPTION
## CHANGELOG

- Value `Subscription-Latest` for parameter `sharePointVersion` now installs the April 2026 PU for SharePoint Subscription
- Updated DSC configurations to [v2.3.0](https://github.com/Yvand/SharePointInfraDsc/releases/tag/releases%2Fv2.3.0), which contains [reliability improvements on the DC and SQL](https://github.com/Yvand/SharePointInfraDsc/blob/main/CHANGELOG.md#230---2026-04-15)
- Minor update to the documentation